### PR TITLE
Changed find option `-name` to `-path` in mapping.txt filters

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,8 +121,8 @@ func runGradleTask(gradleTool, buildFile, tasks, options string) error {
 
 func find(dir, nameInclude, nameExclude string) ([]string, error) {
 	cmdSlice := []string{"find", dir}
-	cmdSlice = append(cmdSlice, "-name", nameInclude)
-	cmdSlice = append(cmdSlice, "!", "-name", nameExclude)
+	cmdSlice = append(cmdSlice, "-path", nameInclude)
+	cmdSlice = append(cmdSlice, "!", "-path", nameExclude)
 
 	log.Detail(cmdex.PrintableCommandArgs(false, cmdSlice))
 


### PR DESCRIPTION
It looks like mapping.txt include/exclude filter uses find with the `-name` instead of `-path`, causing the filters like `*/release/mapping.txt` to fail (return no filenames), despite the fact that this exact pattern is [presented as an example](https://github.com/bitrise-io/steps-gradle-runner/blob/master/step.yml#L97), which should happen according to the [GNU documentation for findutils](https://www.gnu.org/software/findutils/manual/html_node/find_html/Base-Name-Patterns.html#Base-Name-Patterns):

> Because the leading directories are removed, the file names considered for a match with ‘-name’ will never include a slash, so ‘-name a/b’ will never match anything (you probably need to use ‘-path’ instead).

[The step used `-path` previously](https://github.com/bitrise-io/steps-gradle-runner/blob/33df200a10143ede7838bc764af24fa8c6bc7303/step.sh#L77) and I recall it worked correctly.