### PR TITLE
Gradle build file made optional

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,6 +14,7 @@ workflows:
     - test
     - test-multiple-tasks
     - test-subdir
+    - test-no-root-buildfile
 
   test:
     description: "CI workflow - this should always pass!"
@@ -60,6 +61,16 @@ workflows:
     after_run:
     - _common
 
+  test-no-root-buildfile:
+    envs:
+    - SAMPLE_APP_GIT_CLONE_URL: https://github.com/DroidsOnRoids/android-empty-library.git
+    - GRADLE_TASK: assembleDebug
+    - GRADLEW_PATH: "./gradlew"
+    - APK_FILE_EXCLUDE_FILTER: "*-unaligned.apk"
+    - MAPPING_FILE_INCLUDE_FILTER: "*/release/mapping.txt"
+    after_run:
+    - _common
+    
   _common:
     steps:
     - script:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -64,6 +64,7 @@ workflows:
   test-no-root-buildfile:
     envs:
     - SAMPLE_APP_GIT_CLONE_URL: https://github.com/DroidsOnRoids/android-empty-library.git
+    - GRADLE_FILE: ""
     - GRADLE_TASK: assembleDebug
     - GRADLEW_PATH: "./gradlew"
     - APK_FILE_EXCLUDE_FILTER: "*-unaligned.apk"

--- a/main.go
+++ b/main.go
@@ -61,14 +61,12 @@ func (configs ConfigsModel) print() {
 }
 
 func (configs ConfigsModel) validate() (string, error) {
-	// required
-	if configs.GradleFile == "" {
-		return "", errors.New("no GradleFile parameter specified")
-	}
-	if exist, err := pathutil.IsPathExists(configs.GradleFile); err != nil {
-		return "", fmt.Errorf("failed to check if GradleFile exist at: %s, error: %s", configs.GradleFile, err)
-	} else if !exist {
-		return "", fmt.Errorf("gradleFile not exist at: %s", configs.GradleFile)
+	if configs.GradleFile != "" {
+		if exist, err := pathutil.IsPathExists(configs.GradleFile); err != nil {
+			return "", fmt.Errorf("Failed to check if GradleFile exists at: %s, error: %s", configs.GradleFile, err)
+		} else if !exist {
+			return "", fmt.Errorf("GradleFile does not exist at: %s", configs.GradleFile)
+		}
 	}
 
 	if configs.GradleTasks == "" {
@@ -106,7 +104,10 @@ func runGradleTask(gradleTool, buildFile, tasks, options string) error {
 		return err
 	}
 
-	cmdSlice := []string{gradleTool, "--build-file", buildFile}
+	cmdSlice := []string{gradleTool}
+	if buildFile != "" {
+		cmdSlice = append(cmdSlice, "--build-file", buildFile)
+	}
 	cmdSlice = append(cmdSlice, taskSlice...)
 	cmdSlice = append(cmdSlice, optionSlice...)
 

--- a/step.yml
+++ b/step.yml
@@ -28,10 +28,9 @@ toolkit:
 inputs:
   - gradle_file: $GRADLE_BUILD_FILE_PATH
     opts:
-      title: Path to the gradle file to use
+      title: Optional path to the gradle build file to use
       description: |
-        Path to the gradle file to use
-      is_required: true
+        Optional path to the gradle build file to use
   - gradle_task: assemble
     opts:
       title: Gradle task to run


### PR DESCRIPTION
`--build-file` parameter is optional so the corresponding parameter should be optional as well.
Top-level `build.gradle` file may also not exist as shown in a minimal sample project referenced in `test-no-root-buildfile` workflow where there is `settings.gradle` and `build.gradle` in a subdirectory.

BTW `groovy` plugin is applied by default so there may be no buildfiles at all.