### PR TITLE
chore: bump CLI to v2.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.10
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.1
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.1 h1:fCK/37lDiyrgoE9IuZMiFq5MVoc9xHfIq3ufduWhYok=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.1/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3 h1:6/GzIyCWvwLaZNpKytITcFAWaV2uOLm8fSets8lftAA=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
 github.com/bitrise-io/go-steputils v1.0.5 h1:OBH7CPXeqIWFWJw6BOUMQnUb8guspwKr2RhYBhM9tfc=
 github.com/bitrise-io/go-steputils v1.0.5/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42 h1:D5qjBpCpsutIl6aL4jvdFtbvRgP+Y9wHRYOli7hI9z8=

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
@@ -30,6 +30,7 @@ type templateEntry struct {
 	GradleMatch             string
 	MirrorURL               string
 	ApplyToPluginManagement bool
+	UseAsRobolectricRepo    bool
 }
 
 type templateData struct {
@@ -73,6 +74,7 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 			GradleMatch:             m.GradleMatch,
 			MirrorURL:               url,
 			ApplyToPluginManagement: m.ApplyToPluginManagement,
+			UseAsRobolectricRepo:    m.UseAsRobolectricRepo,
 		})
 		logger.Debugf("Mirror %s: region=%s, URL=%s", m.FlagName, region, url)
 	}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/asset/gradle-mirrors.init.gradle.kts.gotemplate
@@ -56,5 +56,12 @@ class InternalRepositoryPlugin : Plugin<Gradle> {
         gradle.afterProject(Action {
             configureMirror.execute(getRepositories())
         })
+        {{- range .Mirrors }}{{ if .UseAsRobolectricRepo }}
+        gradle.afterProject(Action {
+            tasks.withType(Test::class.java).configureEach {
+                systemProperty("robolectric.dependency.repo.url", "{{ .MirrorURL }}")
+            }
+        })
+        {{- end }}{{ end }}
     }
 }

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
@@ -15,6 +15,7 @@ type RepoMirror struct {
 	URLSegment              string // last path segment in the mirror URL, e.g. "central"
 	GradleMatch             string // Kotlin predicate body (using `r` as the repo) that decides whether the repo should be mirrored
 	ApplyToPluginManagement bool   // also apply this mirror to pluginManagement.repositories
+	UseAsRobolectricRepo    bool   // also expose this mirror via the robolectric.dependency.repo.url system property on Test tasks
 }
 
 // KnownMirrors is the registry of supported mirrors.
@@ -22,7 +23,7 @@ type RepoMirror struct {
 // (e.g. apache-central) must run before name-based ones that overwrite the URL.
 var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
-	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`},
+	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.1
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3
 ## explicit; go 1.24.0
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge


### PR DESCRIPTION
Bumps `bitrise-build-cache-cli/v2` from `v2.4.1` to `v2.4.3`.

## What's in v2.4.3

- Robolectric installation now goes through the Bitrise Maven Central mirror via the `robolectric.dependency.repo.url` system property on Test tasks.
- `GradlePluginsMirrorURL` is now gated on the supported-region allowlist — fixes `Connect timed out` for customer-private GCP DCs (e.g. `US_EAST4`) where the mirror host is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)