### PR TITLE
chore: bump bitrise-build-cache-cli to v2.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.10
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3 h1:6/GzIyCWvwLaZNpKytITcFAWaV2uOLm8fSets8lftAA=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4 h1:fbaOQM+xvQekN9YRKx5njhdHLh7QNlgH+Q9YM33E+04=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
 github.com/bitrise-io/go-steputils v1.0.5 h1:OBH7CPXeqIWFWJw6BOUMQnUb8guspwKr2RhYBhM9tfc=
 github.com/bitrise-io/go-steputils v1.0.5/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42 h1:D5qjBpCpsutIl6aL4jvdFtbvRgP+Y9wHRYOli7hI9z8=

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
@@ -25,6 +25,8 @@ var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
+	{FlagName: "jitpack", TemplateID: "JitPack", URLSegment: "jitpack", GradleMatch: `r.getUrl().toString().trimEnd('/') in setOf("https://jitpack.io", "https://www.jitpack.io")`},
+	{FlagName: "gradle-plugin-portal", TemplateID: "PluginPortal", URLSegment: "gradle-plugins", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`, ApplyToPluginManagement: true},
 }
 
 //go:embed asset/gradle-mirrors.init.gradle.kts.gotemplate

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.3
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4
 ## explicit; go 1.24.0
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge


### PR DESCRIPTION
## Summary

Bumps the `bitrise-build-cache-cli` Go module dependency from v2.4.3 to v2.4.4.

Picks up two new mirror entries:
- `gradlePluginPortal()` (PR https://github.com/bitrise-io/bitrise-build-cache-cli/pull/299)
- `jitpack.io` (PR https://github.com/bitrise-io/bitrise-build-cache-cli/pull/300)

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)