### PR TITLE
chore: bump bitrise-build-cache-cli to v2.4.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.10
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.8
 	github.com/bitrise-io/go-steputils v1.0.5
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7 h1:kjGZg8JIj5dhukBHnHKcUc5RyTvxhRLLE3biKn+ezdQ=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.8 h1:pmns8J7/0FZ3AuqLXL32wVqGTeOqINiFq8oOzwrPUnU=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.8/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
 github.com/bitrise-io/go-steputils v1.0.5 h1:OBH7CPXeqIWFWJw6BOUMQnUb8guspwKr2RhYBhM9tfc=
 github.com/bitrise-io/go-steputils v1.0.5/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.42 h1:D5qjBpCpsutIl6aL4jvdFtbvRgP+Y9wHRYOli7hI9z8=

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
@@ -19,10 +19,11 @@ const DatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
 
 // Params bundles the inputs needed to write the Gradle mirrors init script.
 type Params struct {
-	GradleHome string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
-	Mirrors    []RepoMirror // mirrors to install
-	Datacenter string       // datacenter (e.g. "AMS1") used to build the mirror URL
-	Enabled    bool         // when false, Activate is a no-op
+	GradleHome  string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
+	Mirrors     []RepoMirror // mirrors to install
+	Datacenter  string       // datacenter (e.g. "AMS1") used to build the mirror URL
+	Enabled     bool         // when false, Activate is a no-op
+	ProjectRoot string       // project root scanned for scope-gap warnings; empty disables scanning
 }
 
 type templateEntry struct {
@@ -102,6 +103,10 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 	}
 
 	logger.Infof("Gradle mirrors activated")
+
+	if params.ProjectRoot != "" {
+		LogScopeGapWarnings(logger, osProxy, params.ProjectRoot)
+	}
 
 	return nil
 }

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
@@ -25,7 +25,6 @@ var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "jitpack", TemplateID: "JitPack", URLSegment: "jitpack", GradleMatch: `r.getUrl().toString().trimEnd('/') in setOf("https://jitpack.io", "https://www.jitpack.io")`},
 	{FlagName: "gradle-plugin-portal", TemplateID: "PluginPortal", URLSegment: "gradle-plugins", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`, ApplyToPluginManagement: true},
 }
 

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/scope_gap.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/scope_gap.go
@@ -1,0 +1,74 @@
+package mirrors
+
+import (
+	"path/filepath"
+	"regexp"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// gradleScriptCandidates are the script files scanned at activation time.
+// We check the project root + the conventional Android `app/` module dir.
+// Anything declared inside `apply(from = ...)`-loaded scripts' own
+// buildscript {} blocks is invisible to the init script — those scripts'
+// ScriptHandler instances are not reachable from gradle.beforeSettings or
+// gradle.beforeProject hooks. Surfacing the file makes the gap actionable.
+//
+//nolint:gochecknoglobals
+var gradleScriptCandidates = []string{
+	"settings.gradle",
+	"settings.gradle.kts",
+	"build.gradle",
+	"build.gradle.kts",
+	filepath.Join("app", "build.gradle"),
+	filepath.Join("app", "build.gradle.kts"),
+}
+
+//nolint:gochecknoglobals
+var (
+	applyFromKotlinRe = regexp.MustCompile(`apply\s*\(\s*from\s*=`)
+	applyFromGroovyRe = regexp.MustCompile(`\bapply\s+from\s*:`)
+)
+
+// LogScopeGapWarnings scans the project for Gradle scripts that pull in other
+// scripts via `apply(from = ...)`. Repositories declared inside those applied
+// scripts' own buildscript {} blocks are not redirected by the mirror init
+// script, so dependencies they resolve still hit the upstream repo and may
+// fail with rate limits or verification mismatches.
+func LogScopeGapWarnings(logger log.Logger, osProxy utils.OsProxy, projectRoot string) {
+	hits := scanForApplyFrom(osProxy, projectRoot)
+	if len(hits) == 0 {
+		return
+	}
+
+	logger.Warnf("Detected %d Gradle script(s) using `apply(from = ...)`:", len(hits))
+
+	for _, h := range hits {
+		logger.Warnf("  - %s", h)
+	}
+
+	logger.Warnf("Bitrise repository mirrors do NOT cover repositories declared inside applied scripts' own buildscript {} blocks.")
+	logger.Warnf("If those scripts declare e.g. mavenCentral() in a buildscript {} block, dependencies fetched from there go to the upstream repo and may hit rate limits or verification failures.")
+	logger.Warnf("Recommended: move plugin classpath into settings.gradle.kts pluginManagement {}, which the mirror covers.")
+}
+
+func scanForApplyFrom(osProxy utils.OsProxy, projectRoot string) []string {
+	var hits []string
+
+	for _, name := range gradleScriptCandidates {
+		path := filepath.Join(projectRoot, name)
+
+		content, ok, err := osProxy.ReadFileIfExists(path)
+		if err != nil || !ok {
+			continue
+		}
+
+		if applyFromKotlinRe.MatchString(content) || applyFromGroovyRe.MatchString(content) {
+			hits = append(hits, path)
+		}
+	}
+
+	return hits
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
@@ -28,6 +28,11 @@ type ActivatorParams struct {
 	// Empty means DefaultGradleHome.
 	GradleHome string
 
+	// ProjectRoot is the directory scanned for scope-gap warnings (Gradle
+	// scripts using `apply(from = ...)`). Empty falls back to the current
+	// working directory; "-" disables scanning.
+	ProjectRoot string
+
 	// SelectedFlags lists the mirror flag names to enable (e.g. "mavencentral",
 	// "google"). Empty means all mirrors in mirrorsconfig.KnownMirrors.
 	SelectedFlags []string
@@ -66,6 +71,7 @@ type Activator struct {
 	pathModifier pathutil.PathModifier
 
 	gradleHome    string
+	projectRoot   string
 	selectedFlags []string
 	datacenter    string
 	enabled       *bool
@@ -105,6 +111,7 @@ func NewActivator(params ActivatorParams) *Activator {
 		pathModifier: pathModifier,
 
 		gradleHome:    gradleHome,
+		projectRoot:   params.ProjectRoot,
 		selectedFlags: params.SelectedFlags,
 		datacenter:    params.Datacenter,
 		enabled:       params.Enabled,
@@ -128,12 +135,14 @@ func (a *Activator) Activate(_ context.Context) error {
 	enabled := a.resolveEnabled()
 	datacenter := a.resolveDatacenter()
 	selected := mirrorsconfig.FilterByFlagNames(a.selectedFlags)
+	projectRoot := a.resolveProjectRoot()
 
 	if err := mirrorsconfig.Activate(a.logger, a.osProxy, mirrorsconfig.Params{
-		GradleHome: gradleHome,
-		Mirrors:    selected,
-		Datacenter: datacenter,
-		Enabled:    enabled,
+		GradleHome:  gradleHome,
+		Mirrors:     selected,
+		Datacenter:  datacenter,
+		Enabled:     enabled,
+		ProjectRoot: projectRoot,
 	}); err != nil {
 		return fmt.Errorf("activate gradle mirrors: %w", err)
 	}
@@ -159,4 +168,22 @@ func (a *Activator) resolveDatacenter() string {
 	}
 
 	return a.envs[mirrorsconfig.DatacenterEnvKey]
+}
+
+func (a *Activator) resolveProjectRoot() string {
+	switch a.projectRoot {
+	case "-":
+		return ""
+	case "":
+		cwd, err := a.osProxy.Getwd()
+		if err != nil {
+			a.logger.Debugf("Could not determine working directory for scope-gap scan: %s", err)
+
+			return ""
+		}
+
+		return cwd
+	default:
+		return a.projectRoot
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.8
 ## explicit; go 1.24.0
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors


### PR DESCRIPTION
Bump CLI dep to [v2.4.8](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.8). Picks up the jitpack mirror disable (#306) and the gradle-mirrors scope-gap activation-time warning (#305 / ACI-4870).