### PR TITLE
fix(e2e): install missing Android SDK platforms before gradle

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -224,6 +224,13 @@ workflows:
         - repository_url: $TEST_APP_URL
         - clone_into_dir: $CLONE_INTO_DIR
         - branch: $TEST_APP_BRANCH
+    # Older fixture apps (e.g. sample-apps-android-sdk22) pin compileSdkVersion
+    # to a platform that the current CI image does not pre-install. Run the
+    # standard installer so gradle can resolve the requested platform/build-tools
+    # before the self-test step starts compiling.
+    - install-missing-android-tools@3:
+        inputs:
+        - gradlew_path: $CLONE_INTO_DIR/$GRADLEW_PATH
     - path::./:
         title: Self-test
         inputs:


### PR DESCRIPTION
## Summary

The shared `_common` e2e workflow runs `gradle` directly against `sample-apps-android-sdk22` (which pins `compileSdkVersion 27`) without first ensuring the requested SDK platform is installed. Since the current CI image no longer pre-installs `platforms;android-27`, every gradle e2e fails with:

```
Failed to install the following SDK components:
    platforms;android-27 Android SDK Platform 27
Install the missing components using the SDK manager in Android Studio.
```

This blocks the open CLI bump PRs (#126, and downstream #127 which is stacked on it).

## Fix

Add the standard `install-missing-android-tools@3` step to `_common` between the fixture clone and the self-test step. Step inspects the cloned project's gradle config and `sdkmanager`-installs whatever platforms / build-tools / extras it needs, so gradle e2e is now stack-image-independent.

## Test plan

- [ ] CI green on this PR (the same `test` workflow that's failing on #126 should pass here).
- [ ] After merge, rebase / re-run #126 → its e2e should now go green.
- [ ] PR #127 (the wrap PR stacked on #126) inherits the fix.